### PR TITLE
modify console warning about node major/minor versions

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -7,10 +7,9 @@ const [major, minor] = process.version
   .map((str) => parseInt(str, 10));
 
 if (
-  !(major === 12 && minor >= 19)
-  && !(major === 14 && minor >= 15)
+  !(major >= 18 && minor >= 15)
 ) {
-  attention.warn('Unsupported Node.js runtime version. Use ^12.19.0 or ^14.15.0');
+  attention.warn('Unsupported Node.js runtime version. Use >=18.15.0');
 }
 
 const url = require('url');


### PR DESCRIPTION
- instead versions v12 or v14, print warning log when version is lower than 18.15.0

References: node 18 upgrade